### PR TITLE
Add argparser argument for configuring SGLang server port

### DIFF
--- a/olmocr/pipeline.py
+++ b/olmocr/pipeline.py
@@ -88,7 +88,7 @@ process_pool = ProcessPoolExecutor(max_workers=min(multiprocessing.cpu_count() /
 # Filter object, cached so it will only get loaded when/if you need it
 get_pdf_filter = cache(lambda: PdfFilter(languages_to_keep={Language.ENGLISH, None}, apply_download_spam_check=True, apply_form_check=True))
 
-SGLANG_SERVER_PORT = 30024
+SGLANG_SERVER_PORT = None
 
 
 @dataclass(frozen=True)
@@ -938,9 +938,13 @@ async def main():
     )
     parser.add_argument("--beaker_gpus", type=int, default=1, help="Number of gpu replicas to run")
     parser.add_argument("--beaker_priority", type=str, default="normal", help="Beaker priority level for the job")
+    parser.add_argument("--port", type=int, default=30024, help="Port to use for the SGLang server")
     args = parser.parse_args()
 
     global workspace_s3, pdf_s3
+    # set the global SGLANG_SERVER_PORT from args
+    global SGLANG_SERVER_PORT
+    SGLANG_SERVER_PORT = args.port
 
     # setup the job to work in beaker environment, load secrets, adjust logging, etc.
     if "BEAKER_JOB_NAME" in os.environ:


### PR DESCRIPTION
Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Add argparse argument for SGLang server port configuration. This prevents port conflicts when running multiple pipelines simultaneously on a single node in cluster environments (LSF or SLURM), allowing to specify different ports for each instance.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## How to use

- In LSF
```shell
JOB_ID=${LSB_JOBID:-0}
PORT=$((30000 + (JOB_ID % 1000)))
python -m olmocr.pipeline --port $PORT "$@"
```
- In SLURM
```shell
JOB_ID=${SLURM_JOB_ID:-0}
PORT=$((30000 + (JOB_ID % 1000)))
python -m olmocr.pipeline --port $PORT "$@"
```
