### PR TITLE
Add script to convert JSONL files to Markdown format

### DIFF
--- a/scripts/jsonl_to_markdown.py
+++ b/scripts/jsonl_to_markdown.py
@@ -24,13 +24,10 @@ def jsonl_to_markdown(input_file, output_dir):
                 data = json.loads(line)
                 text_content = data.get("text", "")
 
-                # Convert to Markdown format
-                markdown_content = f"# Extracted Content (Line {i + 1})\n\n{text_content}"
-
                 # Save to a Markdown file
                 output_file = os.path.join(output_dir, f"line_{i + 1}.md")
                 with open(output_file, 'w', encoding='utf-8') as md_file:
-                    md_file.write(markdown_content)
+                    md_file.write(text_content)
 
                 print(f"Extracted and saved line {i + 1} to {output_file}")
             except json.JSONDecodeError as e:

--- a/scripts/jsonl_to_markdown.py
+++ b/scripts/jsonl_to_markdown.py
@@ -1,0 +1,58 @@
+import json
+import os
+import sys
+
+# This is a simple script to convert JSONL files to Markdown format.
+# It reads each line of the JSONL file, extracts the 'text' field,
+# and saves it as a Markdown file with the line number as the filename.
+# The script also handles potential JSON decoding errors and prints relevant messages.
+def jsonl_to_markdown(input_file, output_dir):
+    """
+    Reads a JSONL file, extracts the 'text' field from each line, and saves it as a Markdown file.
+
+    Args:
+        input_file (str): Path to the input JSONL file.
+        output_dir (str): Directory to save the Markdown files.
+    """
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(input_file, 'r', encoding='utf-8') as file:
+        for i, line in enumerate(file):
+            try:
+                # Parse the JSON line
+                data = json.loads(line)
+                text_content = data.get("text", "")
+
+                # Convert to Markdown format
+                markdown_content = f"# Extracted Content (Line {i + 1})\n\n{text_content}"
+
+                # Save to a Markdown file
+                output_file = os.path.join(output_dir, f"line_{i + 1}.md")
+                with open(output_file, 'w', encoding='utf-8') as md_file:
+                    md_file.write(markdown_content)
+
+                print(f"Extracted and saved line {i + 1} to {output_file}")
+            except json.JSONDecodeError as e:
+                print(f"Error decoding JSON on line {i + 1}: {e}")
+            except Exception as e:
+                print(f"Unexpected error on line {i + 1}: {e}")
+
+# Example usage
+# input_jsonl_file = "/path/to/test.jsonl"  # Replace with the actual path to your JSONL file
+# output_directory = "/path/to/output_markdown"  # Replace with the desired output directory
+# jsonl_to_markdown(input_jsonl_file, output_directory)
+
+# This is the main entrypoint to use the script from the command line.
+# It takes two arguments: the input JSONL file and the output directory.
+# The script will create the output directory if it does not exist.
+if __name__ == "__main__":
+
+  if len(sys.argv) != 3:
+    print("Usage: python jsonl_to_markdown.py <input_file> <output_dir>")
+    sys.exit(1)
+
+  input_file = sys.argv[1]
+  output_dir = sys.argv[2]
+
+  jsonl_to_markdown(input_file, output_dir)


### PR DESCRIPTION
Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- This PR adds a simple script in the scripts folder that helps to convert a JSONL file into multiple markdown files.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
