### PR TITLE
fix jsonl_to_markdown

### DIFF
--- a/scripts/jsonl_to_markdown.py
+++ b/scripts/jsonl_to_markdown.py
@@ -1,13 +1,15 @@
+#!/usr/bin/env python3
 import json
 import os
 import sys
+from pathlib import Path
 
 
 # This is a simple script to convert JSONL files to Markdown format.
 # It reads each line of the JSONL file, extracts the 'text' field,
 # and saves it as a Markdown file with the line number as the filename.
 # The script also handles potential JSON decoding errors and prints relevant messages.
-def jsonl_to_markdown(input_file, output_dir):
+def jsonl_to_markdown(input_file: str, output_dir: str) -> None:
     """
     Reads a JSONL file, extracts the 'text' field from each line, and saves it as a Markdown file.
 
@@ -15,26 +17,30 @@ def jsonl_to_markdown(input_file, output_dir):
         input_file (str): Path to the input JSONL file.
         output_dir (str): Directory to save the Markdown files.
     """
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    # Create output directory if it doesn't exist
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
 
     with open(input_file, "r", encoding="utf-8") as file:
-        for i, line in enumerate(file):
+        for i, line in enumerate(file, 1):
             try:
                 # Parse the JSON line
                 data = json.loads(line)
                 text_content = data.get("text", "")
 
-                # Save to a Markdown file
-                output_file = os.path.join(output_dir, f"line_{i + 1}.md")
-                with open(output_file, "w", encoding="utf-8") as md_file:
-                    md_file.write(text_content)
+                # Convert to Markdown format
+                markdown_content = f"# Extracted Content (Line {i})\n\n{text_content}"
 
-                print(f"Extracted and saved line {i + 1} to {output_file}")
+                # Save to a Markdown file
+                output_file = output_path / f"line_{i}.md"
+                with open(output_file, "w", encoding="utf-8") as md_file:
+                    md_file.write(markdown_content)
+
+                print(f"Extracted and saved line {i} to {output_file}")
             except json.JSONDecodeError as e:
-                print(f"Error decoding JSON on line {i + 1}: {e}")
+                print(f"Error decoding JSON on line {i}: {e}")
             except Exception as e:
-                print(f"Unexpected error on line {i + 1}: {e}")
+                print(f"Unexpected error on line {i}: {e}")
 
 
 # Example usage


### PR DESCRIPTION

<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #162

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Add `jsonl_to_markdown.py` utility script to convert JSONL files to Markdown format
- Script extracts the 'text' field from each line in a JSONL file and saves it as a separate Markdown file
- Include proper error handling for JSON decoding and file operations
- Add example usage and documentation

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#making-a-pull-request) section of the `CONTRIBUTING` docs.
- [x] I've updated or added relevant docstrings following the syntax described in the [Writing docstrings](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

fixes  #162 
