### PR TITLE
Fix marker benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,18 +62,6 @@ We also ship a comprehensive benchmark suite covering over 7,000 test cases acro
   </thead>
   <tbody>
     <tr>
-      <td align="left">Marker v1.6.2</td>
-      <td align="center">24.3</td>
-      <td align="center">22.1</td>
-      <td align="center">69.8</td>
-      <td align="center">24.3</td>
-      <td align="center">87.1</td>
-      <td align="center">71.0</td>
-      <td align="center">76.9</td>
-      <td align="center"><strong>99.5</strong></td>
-      <td align="center">59.4 ± 1.1</td>
-    </tr>
-    <tr>
       <td align="left">MinerU v1.3.10</td>
       <td align="center">75.4</td>
       <td align="center">47.4</td>
@@ -87,7 +75,7 @@ We also ship a comprehensive benchmark suite covering over 7,000 test cases acro
     </tr>
     <tr>
       <td align="left">Mistral OCR API</td>
-      <td align="center"><strong>77.2</strong></td>
+      <td align="center">77.2</td>
       <td align="center">67.5</td>
       <td align="center">60.6</td>
       <td align="center">29.3</td>
@@ -96,6 +84,18 @@ We also ship a comprehensive benchmark suite covering over 7,000 test cases acro
       <td align="center">77.1</td>
       <td align="center">99.4</td>
       <td align="center">72.0 ± 1.1</td>
+    </tr>
+    <tr>
+      <td align="left">Marker v1.7.4 (hybrid)</td>
+      <td align="center"><strong>77.7</strong></td>
+      <td align="center">71.2</td>
+      <td align="center"><strong>78.1</strong></td>
+      <td align="center">32.3</td>
+      <td align="center">83.4</td>
+      <td align="center">73.8</td>
+      <td align="center">79.0</td>
+      <td align="center">99.2</td>
+      <td align="center">74.3 ± 1.1</td>
     </tr>
     <tr>
       <td align="left">olmOCR v0.1.68 (pipeline.py)</td>

--- a/olmocr/bench/README.md
+++ b/olmocr/bench/README.md
@@ -46,16 +46,28 @@ to run it against your own OCR tools. Your tool just needs to support Markdown o
       <td align="center">48.3 ± 1.1</td>
     </tr>
     <tr>
-      <td align="left">Marker v1.6.2</td>
-      <td align="center">24.3</td>
-      <td align="center">22.1</td>
-      <td align="center">69.8</td>
-      <td align="center">24.3</td>
-      <td align="center">87.1</td>
-      <td align="center">71.0</td>
-      <td align="center">76.9</td>
-      <td align="center"><strong>99.5</strong></td>
-      <td align="center">59.4 ± 1.1</td>
+      <td align="left">Marker v1.7.4 (base)</td>
+      <td align="center"><strong>77.7</strong></td>
+      <td align="center">59.6</td>
+      <td align="center">57.9</td>
+      <td align="center">27.8</td>
+      <td align="center">85.3</td>
+      <td align="center">73.5</td>
+      <td align="center">78.7</td>
+      <td align="center">99.1</td>
+      <td align="center">70.0 ± 1.1</td>
+    </tr>
+    <tr>
+      <td align="left">Marker v1.7.4 (hybrid)</td>
+      <td align="center"><strong>77.7</strong></td>
+      <td align="center">71.2</td>
+      <td align="center"><strong>78.1</strong></td>
+      <td align="center">32.3</td>
+      <td align="center">83.4</td>
+      <td align="center">73.8</td>
+      <td align="center">79.0</td>
+      <td align="center">99.2</td>
+      <td align="center">74.3 ± 1.1</td>
     </tr>
     <tr>
       <td align="left">MinerU v1.3.10</td>
@@ -71,14 +83,14 @@ to run it against your own OCR tools. Your tool just needs to support Markdown o
     </tr>
     <tr>
       <td align="left">Mistral OCR API</td>
-      <td align="center"><strong>77.2</strong></td>
+      <td align="center">77.2</td>
       <td align="center">67.5</td>
       <td align="center">60.6</td>
       <td align="center">29.3</td>
       <td align="center">93.6</td>
       <td align="center">71.3</td>
       <td align="center">77.1</td>
-      <td align="center">99.4</td>
+      <td align="center"><strong>99.4</strong></td>
       <td align="center">72.0 ± 1.1</td>
     </tr>
     <tr>
@@ -121,7 +133,7 @@ to run it against your own OCR tools. Your tool just needs to support Markdown o
       <td align="left">Gemini Flash 2 (Anchored)</td>
       <td align="center">54.5</td>
       <td align="center">56.1</td>
-      <td align="center"><strong>72.1</strong></td>
+      <td align="center">72.1</td>
       <td align="center">34.2</td>
       <td align="center">64.7</td>
       <td align="center">61.5</td>

--- a/olmocr/bench/runners/run_marker.py
+++ b/olmocr/bench/runners/run_marker.py
@@ -4,6 +4,7 @@ import tempfile
 from marker.converters.pdf import PdfConverter
 from marker.models import create_model_dict
 from marker.output import text_from_rendered
+from marker.config.parser import ConfigParser
 from pypdf import PdfReader, PdfWriter
 
 _marker_converter = None
@@ -12,13 +13,28 @@ _marker_converter = None
 def run_marker(pdf_path: str, page_num: int = 1) -> str:
     global _marker_converter
 
+    google_key_exists = os.getenv("GOOGLE_API_KEY") is not None
+
     if _marker_converter is None:
         # Create a configuration dictionary with the necessary settings
         config = {
-            "texify_inline_spans": True,  # This enables conversion of inline math to LaTeX
+            "format_lines": True,  # This enables conversion of inline math to LaTeX
+            "use_llm": google_key_exists, # Activate LLM mode if google key is specified
+            "disable_tqdm": True,  # Disable tqdm for cleaner output
+            "recognition_batch_size": 256,
+            "layout_batch_size": 48,
+            "detection_batch_size": 48,
+            "equation_batch_size": 64,
+            "table_rec_batch_size": 48,
+            "ocr_error_batch_size": 64,
         }
+        config_parser = ConfigParser(config)
 
-        _marker_converter = PdfConverter(artifact_dict=create_model_dict(), config=config)
+        _marker_converter = PdfConverter(
+            artifact_dict=create_model_dict(),
+            config=config_parser.generate_config_dict(),
+            llm_service=config_parser.get_llm_service(),
+        )
 
     # Extract the specific page from the PDF
     pdf_to_process = pdf_path

--- a/olmocr/bench/runners/run_marker.py
+++ b/olmocr/bench/runners/run_marker.py
@@ -18,7 +18,7 @@ def run_marker(pdf_path: str, page_num: int = 1) -> str:
     if _marker_converter is None:
         # Create a configuration dictionary with the necessary settings
         config = {
-            "format_lines": True,  # This enables conversion of inline math to LaTeX
+            "force_ocr": True,  # This enables conversion of inline math to LaTeX
             "use_llm": google_key_exists, # Activate LLM mode if google key is specified
             "disable_tqdm": True,  # Disable tqdm for cleaner output
             "recognition_batch_size": 256,

--- a/olmocr/bench/runners/run_marker.py
+++ b/olmocr/bench/runners/run_marker.py
@@ -13,13 +13,11 @@ _marker_converter = None
 def run_marker(pdf_path: str, page_num: int = 1) -> str:
     global _marker_converter
 
-    google_key_exists = os.getenv("GOOGLE_API_KEY") is not None
-
     if _marker_converter is None:
         # Create a configuration dictionary with the necessary settings
         config = {
             "force_ocr": True,  # This enables conversion of inline math to LaTeX
-            "use_llm": google_key_exists, # Activate LLM mode if google key is specified
+            "use_llm": False, # We would prefer to run just plain marker for reporting bench results, not hybrid mode
             "disable_tqdm": True,  # Disable tqdm for cleaner output
             "recognition_batch_size": 256,
             "layout_batch_size": 48,
@@ -33,7 +31,6 @@ def run_marker(pdf_path: str, page_num: int = 1) -> str:
         _marker_converter = PdfConverter(
             artifact_dict=create_model_dict(),
             config=config_parser.generate_config_dict(),
-            llm_service=config_parser.get_llm_service(),
         )
 
     # Extract the specific page from the PDF

--- a/olmocr/bench/tests.py
+++ b/olmocr/bench/tests.py
@@ -123,6 +123,8 @@ def normalize_text(md_content: str) -> str:
     # Remove markdown bold formatting (** or __ for bold)
     md_content = re.sub(r"\*\*(.*?)\*\*", r"\1", md_content)
     md_content = re.sub(r"__(.*?)__", r"\1", md_content)
+    md_content = re.sub(r"</?b>", "", md_content)  # Remove <b> tags if they exist
+    md_content = re.sub(r"</?i>", "", md_content)  # Remove <i> tags if they exist
 
     # Remove markdown italics formatting (* or _ for italics)
     md_content = re.sub(r"\*(.*?)\*", r"\1", md_content)

--- a/scripts/pareto_plot.py
+++ b/scripts/pareto_plot.py
@@ -64,7 +64,7 @@ data = {
         "MinerU",
         "Gemini Flash 2",
         "Gemini Flash 2 (Batch)",
-        "Marker v1.6.2",
+        "Marker v1.7.4",
         "Ours",
         "Qwen 2 VL",
         "Qwen 2.5 VL",
@@ -77,7 +77,7 @@ data = {
         61.5,  # MinerU
         63.8,  # Gemini Flash 2 (Anchored)
         63.8,  # Same performance for batch
-        59.4,  # marker v1.6.2
+        74.3,  # marker v1.7.4 hybrid
         77.4,  # Ours (performance is the same across hardware)
         31.5,  # Qwen2VL
         65.5,  # Qwen2.5VL
@@ -94,7 +94,7 @@ model_categories = {
     "MinerU": "Open Source Tool",
     "Gemini Flash 2": "Commercial VLM",
     "Gemini Flash 2 (Batch)": "Commercial VLM",
-    "Marker v1.6.2": "Open Source Tool",
+    "Marker v1.7.4": "Open Source Tool",
     "Ours": "Ours",
     "Qwen 2 VL": "Open VLM",
     "Qwen 2.5 VL": "Open VLM",
@@ -132,7 +132,7 @@ model_label_offsets = {
     "MinerU": [-15, -20],
     "Gemini Flash 2": [-10, 10],
     "Gemini Flash 2 (Batch)": [-50, -15],
-    "Marker v1.6.2": [-35, -20],
+    "Marker v1.7.4": [-35, -20],
     "Ours": [-20, 10],
     "Qwen 2 VL": [-35, 10],
     "Qwen 2.5 VL": [-35, 10],

--- a/scripts/pareto_plot.py
+++ b/scripts/pareto_plot.py
@@ -64,12 +64,12 @@ data = {
         "MinerU",
         "Gemini Flash 2",
         "Gemini Flash 2 (Batch)",
-        "Marker v1.7.4",
+        "Marker v1.7.5",
         "Ours",
         "Qwen 2 VL",
         "Qwen 2.5 VL",
     ],
-    COST_COLUMN_NAME: [12480, 6240, 1000, 596, 499, 249, 75, 178, 178, 178],  # Same cost as Ours  # Same cost as Ours
+    COST_COLUMN_NAME: [12480, 6240, 1000, 596, 499, 249, 235, 178, 178, 178],  # Same cost as Ours  # Same cost as Ours
     PERF_COLUMN_NAME: [
         69.9,  # GPT-4o (Anchored)
         69.9,  # Same performance for batch
@@ -77,7 +77,7 @@ data = {
         61.5,  # MinerU
         63.8,  # Gemini Flash 2 (Anchored)
         63.8,  # Same performance for batch
-        70.0,  # marker v1.7.4 base
+        70.1,  # marker v1.7.5 base
         77.4,  # Ours (performance is the same across hardware)
         31.5,  # Qwen2VL
         65.5,  # Qwen2.5VL
@@ -94,7 +94,7 @@ model_categories = {
     "MinerU": "Open Source Tool",
     "Gemini Flash 2": "Commercial VLM",
     "Gemini Flash 2 (Batch)": "Commercial VLM",
-    "Marker v1.7.4": "Open Source Tool",
+    "Marker v1.7.5": "Open Source Tool",
     "Ours": "Ours",
     "Qwen 2 VL": "Open VLM",
     "Qwen 2.5 VL": "Open VLM",
@@ -132,7 +132,7 @@ model_label_offsets = {
     "MinerU": [-15, -20],
     "Gemini Flash 2": [-10, 10],
     "Gemini Flash 2 (Batch)": [-50, -15],
-    "Marker v1.7.4": [-35, -20],
+    "Marker v1.7.5": [-20, 15],
     "Ours": [-20, 10],
     "Qwen 2 VL": [-35, 10],
     "Qwen 2.5 VL": [-35, 10],

--- a/scripts/pareto_plot.py
+++ b/scripts/pareto_plot.py
@@ -69,7 +69,7 @@ data = {
         "Qwen 2 VL",
         "Qwen 2.5 VL",
     ],
-    COST_COLUMN_NAME: [12480, 6240, 1000, 596, 499, 249, 235, 178, 178, 178],  # Same cost as Ours  # Same cost as Ours
+    COST_COLUMN_NAME: [12480, 6240, 1000, 596, 499, 249, 75, 178, 178, 178],  # Same cost as Ours  # Same cost as Ours
     PERF_COLUMN_NAME: [
         69.9,  # GPT-4o (Anchored)
         69.9,  # Same performance for batch
@@ -77,7 +77,7 @@ data = {
         61.5,  # MinerU
         63.8,  # Gemini Flash 2 (Anchored)
         63.8,  # Same performance for batch
-        74.3,  # marker v1.7.4 hybrid
+        70.0,  # marker v1.7.4 base
         77.4,  # Ours (performance is the same across hardware)
         31.5,  # Qwen2VL
         65.5,  # Qwen2.5VL


### PR DESCRIPTION
Changes proposed in this pull request:
- Bump marker to latest version
- Fix some config passing
- Add marker hybrid mode

I noticed that this benchmark was math-heavy, but was using a version of marker that didn't support inline math well.  Also added benchmarks for the hybrid mode marker version.

## Before submitting

- [X] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [X] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
