### PR TITLE
Fix broken train config

### DIFF
--- a/olmocr/train/config/qwen2vl-7b-lora.yaml
+++ b/olmocr/train/config/qwen2vl-7b-lora.yaml
@@ -16,12 +16,12 @@ train_data:
   sources:
     - name: openai_batch_data_v5_1_train
       response_glob_path: /data/jakep/pdfdata/openai_batch_data_v5_1_train_done/*.json
-      target_longest_image_dim: 1024
-      target_anchor_text_len: 6000
+      target_longest_image_dim: [1024]
+      target_anchor_text_len: [6000]
     - name: openai_batch_data_v5_1_iabooks_train
       response_glob_path: /data/jakep/pdfdata/openai_batch_data_v5_1_iabooks_train_done/*.json
-      target_longest_image_dim: 1024
-      target_anchor_text_len: 6000
+      target_longest_image_dim: [1024]
+      target_anchor_text_len: [6000]
 
 valid_data:
   cache_location: /data/jakep/pdfdata/pdelfin_cache
@@ -30,12 +30,12 @@ valid_data:
     # These tend to be small, so you can load from s3 it's no big deal
     - name: openai_batch_data_v5_1_eval
       response_glob_path: s3://ai2-oe-data/jakep/pdfdata/openai_batch_done_v5_1_eval/*.json
-      target_longest_image_dim: 1024
-      target_anchor_text_len: 6000
+      target_longest_image_dim: [1024]
+      target_anchor_text_len: [6000]
     - name: openai_batch_data_v5_1_iabooks_eval
       response_glob_path: s3://ai2-oe-data/jakep/pdfdata/openai_batch_done_v5_1_iabooks_eval/*.json
-      target_longest_image_dim: 1024
-      target_anchor_text_len: 6000
+      target_longest_image_dim: [1024]
+      target_anchor_text_len: [6000]
 
 
 


### PR DESCRIPTION
If the ``target_longest_image_dim`` and ``target_anchor_text_len`` are not wrapped in a list, the following error occurs (shortened version):

```
12.41   File "/usr/local/lib/python3.12/dist-packages/omegaconf/listconfig.py", line 614, in _set_value
12.41     self._set_value_impl(value, flags)
12.41   File "/usr/local/lib/python3.12/dist-packages/omegaconf/listconfig.py", line 646, in _set_value_impl
12.41     raise ValidationError(msg)
12.41 omegaconf.errors.ValidationError: Invalid value assigned: AnyNode is not a ListConfig, list or tuple.
12.41     full_key: target_longest_image_dim
12.41     reference_type=SourceConfig
12.41     object_type=SourceConfig
```

<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- fixes a broken train config by wrapping single elements in a list

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
