### PR TITLE
Expose --gpu_memory_utilization / --max_model_len flags and startup hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,11 +242,11 @@ python -m olmocr.pipeline ./localworkspace --markdown --pdfs olmocr-sample.pdf
 
 ```bash
 python -m olmocr.pipeline --help
-usage: pipeline.py [-h] [--pdfs PDFS] [--workspace_profile WORKSPACE_PROFILE] [--pdf_profile PDF_PROFILE] [--pages_per_group PAGES_PER_GROUP]
-                   [--max_page_retries MAX_PAGE_RETRIES] [--max_page_error_rate MAX_PAGE_ERROR_RATE] [--workers WORKERS] [--apply_filter] [--stats] [--model MODEL]
-                   [--model_max_context MODEL_MAX_CONTEXT] [--model_chat_template MODEL_CHAT_TEMPLATE] [--target_longest_image_dim TARGET_LONGEST_IMAGE_DIM]
-                   [--target_anchor_text_len TARGET_ANCHOR_TEXT_LEN] [--beaker] [--beaker_workspace BEAKER_WORKSPACE] [--beaker_cluster BEAKER_CLUSTER]
-                   [--beaker_gpus BEAKER_GPUS] [--beaker_priority BEAKER_PRIORITY]
+usage: pipeline.py [-h] [--pdfs [PDFS ...]] [--workspace_profile WORKSPACE_PROFILE] [--pdf_profile PDF_PROFILE] [--pages_per_group PAGES_PER_GROUP] [--max_page_retries MAX_PAGE_RETRIES]
+                   [--max_page_error_rate MAX_PAGE_ERROR_RATE] [--workers WORKERS] [--apply_filter] [--stats] [--markdown] [--model MODEL] [--gpu-memory-utilization GPU_MEMORY_UTILIZATION]
+                   [--max_model_len MAX_MODEL_LEN] [--model_max_context MODEL_MAX_CONTEXT] [--model_chat_template MODEL_CHAT_TEMPLATE] [--target_longest_image_dim TARGET_LONGEST_IMAGE_DIM]
+                   [--target_anchor_text_len TARGET_ANCHOR_TEXT_LEN] [--beaker] [--beaker_workspace BEAKER_WORKSPACE] [--beaker_cluster BEAKER_CLUSTER] [--beaker_gpus BEAKER_GPUS]
+                   [--beaker_priority BEAKER_PRIORITY] [--port PORT] [--tensor-parallel-size TENSOR_PARALLEL_SIZE] [--data-parallel-size DATA_PARALLEL_SIZE]
                    workspace
 
 Manager for running millions of PDFs through a batch inference pipeline
@@ -273,6 +273,10 @@ options:
   --markdown            Also write natural text to markdown files preserving the folder structure of the input pdfs
   --model MODEL         List of paths where you can find the model to convert this pdf. You can specify several different paths here, and the script will try to use the
                         one which is fastest to access
+  --gpu-memory-utilization GPU_MEMORY_UTILIZATION
+                        Fraction of VRAM vLLM may pre-allocate for KV-cache (passed through to vllm serve).
+  --max_model_len MAX_MODEL_LEN
+                        Upper bound (tokens) vLLM will allocate KV-cache for; passed through to vllm serve as --max-model-len.
   --model_max_context MODEL_MAX_CONTEXT
                         Maximum context length that the model was fine tuned under
   --model_chat_template MODEL_CHAT_TEMPLATE

--- a/olmocr/pipeline.py
+++ b/olmocr/pipeline.py
@@ -581,6 +581,8 @@ async def vllm_server_task(model_name_or_path, args, semaphore):
         str(args.tensor_parallel_size),
         "--data-parallel-size",
         str(args.data_parallel_size),
+        "--gpu-memory-utilization", str(args.gpu_memory_utilization),
+        "--max-model-len", str(args.max_model_len),   
     ]
 
     proc = await asyncio.create_subprocess_exec(
@@ -1007,6 +1009,10 @@ async def main():
         help="List of paths where you can find the model to convert this pdf. You can specify several different paths here, and the script will try to use the one which is fastest to access",
         default="allenai/olmOCR-7B-0225-preview",
     )
+
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.95, help="Fraction of VRAM vLLM may pre-allocate for KV-cache " "(passed through to vllm serve).")
+    parser.add_argument("--max_model_len", type=int, default=32768, help="Upper bound (tokens) vLLM will allocate KV-cache for; " "passed through to vllm serve as --max-model-len.",)
+
     parser.add_argument("--model_max_context", type=int, default="8192", help="Maximum context length that the model was fine tuned under")
     parser.add_argument("--model_chat_template", type=str, default="qwen2-vl", help="Chat template to pass to vllm server")
     parser.add_argument("--target_longest_image_dim", type=int, help="Dimension on longest side to use for rendering the pdf pages", default=1024)
@@ -1026,6 +1032,11 @@ async def main():
     parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1, help="Tensor parallel size for vLLM")
     parser.add_argument("--data-parallel-size", "-dp", type=int, default=1, help="Data parallel size for vLLM")
     args = parser.parse_args()
+
+    logger.info(
+        "If you run out of GPU memory during start-up or get 'KV cache is larger than available memory' errors, retry with lower values, e.g. --gpu_memory_utilization 0.80  --max_model_len 16384"
+    )
+    logger.info("Current defaults: gpu_memory_utilization=%.2f  max_model_len=%d" % (args.gpu_memory_utilization, args.max_model_len))
 
     global workspace_s3, pdf_s3
     # set the global BASE_SERVER_PORT from args


### PR DESCRIPTION
Pipeline crashes on high-VRAM cards because two different `--gpu-memory-utilization` flags (0.95 **and** 0.80) are passed to  vLLM; the second one wins → KV-cache too small.
Users on smaller GPUs currently have to edit source to change either flag.

### Changes

1. **pipeline.py**
   * Adds CLI flags  
     * `--gpu_memory_utilization` (default **0.95**, matches previous   hard-coded value).  
     * `--max_model_len` (default **32768**, matches previous constant).
   * Prints a one-time startup hint:

     > “If you run out of GPU memory … try `--gpu_memory_utilization 0.80 --max_model_len 16384`.”

2. **README.md**  
   Updated pipeline.py syntax

* Fix verified on:  
  * RTX 4090 24 GB – server starts, `Available KV cache memory: 3.66 GiB`.

Closes #269 
