### PR TITLE
Forward unknown args to vLLM

### DIFF
--- a/olmocr/pipeline.py
+++ b/olmocr/pipeline.py
@@ -570,7 +570,7 @@ async def worker(args, work_queue: WorkQueue, semaphore, worker_id):
             semaphore.release()
 
 
-async def vllm_server_task(model_name_or_path, args, semaphore):
+async def vllm_server_task(model_name_or_path, args, semaphore, unknown_args=None):
     cmd = [
         "vllm",
         "serve",
@@ -593,6 +593,9 @@ async def vllm_server_task(model_name_or_path, args, semaphore):
 
     if args.max_model_len is not None:
         cmd.extend(["--max-model-len", str(args.max_model_len)])
+
+    if unknown_args:
+        cmd.extend(unknown_args)
 
     proc = await asyncio.create_subprocess_exec(
         *cmd,
@@ -683,12 +686,12 @@ async def vllm_server_task(model_name_or_path, args, semaphore):
     await asyncio.gather(stdout_task, stderr_task, timeout_task, return_exceptions=True)
 
 
-async def vllm_server_host(model_name_or_path, args, semaphore):
+async def vllm_server_host(model_name_or_path, args, semaphore, unknown_args=None):
     MAX_RETRIES = 5
     retry = 0
 
     while retry < MAX_RETRIES:
-        await vllm_server_task(model_name_or_path, args, semaphore)
+        await vllm_server_task(model_name_or_path, args, semaphore, unknown_args)
         logger.warning("VLLM server task ended")
         retry += 1
 
@@ -998,7 +1001,10 @@ def print_stats(args, root_work_queue):
 
 
 async def main():
-    parser = argparse.ArgumentParser(description="Manager for running millions of PDFs through a batch inference pipeline")
+    parser = argparse.ArgumentParser(
+        description="Manager for running millions of PDFs through a batch inference pipeline. "
+        "Unknown arguments are forwarded to vLLM."
+    )
     parser.add_argument(
         "workspace",
         help="The filesystem path where work will be stored, can be a local folder, or an s3 path if coordinating work with many workers, s3://bucket/prefix/ ",
@@ -1030,7 +1036,10 @@ async def main():
     parser.add_argument("--target_anchor_text_len", type=int, help="Maximum amount of anchor text to use (characters), not used for new models", default=-1)
     parser.add_argument("--guided_decoding", action="store_true", help="Enable guided decoding for model YAML type outputs")
 
-    vllm_group = parser.add_argument_group("VLLM Forwarded arguments")
+    vllm_group = parser.add_argument_group(
+        "VLLM arguments", 
+        "These arguments are passed to vLLM. Any unrecognized arguments are also automatically forwarded to vLLM."
+    )
     vllm_group.add_argument(
         "--gpu-memory-utilization", type=float, help="Fraction of VRAM vLLM may pre-allocate for KV-cache " "(passed through to vllm serve)."
     )
@@ -1051,7 +1060,7 @@ async def main():
     beaker_group.add_argument("--beaker_gpus", type=int, default=1, help="Number of gpu replicas to run")
     beaker_group.add_argument("--beaker_priority", type=str, default="normal", help="Beaker priority level for the job")
 
-    args = parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
 
     logger.info(
         "If you run out of GPU memory during start-up or get 'KV cache is larger than available memory' errors, retry with lower values, e.g. --gpu_memory_utilization 0.80  --max_model_len 16384"
@@ -1196,7 +1205,7 @@ async def main():
     # As soon as one worker is no longer saturating the gpu, the next one can start sending requests
     semaphore = asyncio.Semaphore(1)
 
-    vllm_server = asyncio.create_task(vllm_server_host(model_name_or_path, args, semaphore))
+    vllm_server = asyncio.create_task(vllm_server_host(model_name_or_path, args, semaphore, unknown_args))
 
     await vllm_server_ready()
 

--- a/olmocr/pipeline.py
+++ b/olmocr/pipeline.py
@@ -1001,10 +1001,7 @@ def print_stats(args, root_work_queue):
 
 
 async def main():
-    parser = argparse.ArgumentParser(
-        description="Manager for running millions of PDFs through a batch inference pipeline. "
-        "Unknown arguments are forwarded to vLLM."
-    )
+    parser = argparse.ArgumentParser(description="Manager for running millions of PDFs through a batch inference pipeline.")
     parser.add_argument(
         "workspace",
         help="The filesystem path where work will be stored, can be a local folder, or an s3 path if coordinating work with many workers, s3://bucket/prefix/ ",


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #287 

Changes proposed in this pull request:
- Forward unknown command line arguments to vLLM.

This might be a bit of a silly approach, but theres a ton of arguments for vLLM, and patching in argument by argument as a new one is needed seems unnecessary, so I'm just forwarding any unknown argument to vLLM. Happy to hear alternatives.

I was testing OlmOCR + vLLM 0.10.0 with data parallelism on some B200s as 0.10.0 has improved support for Blackwell, but I was running into issues with the multimodal input cache so I needed to add `--disable-mm-preprocessor-cache` (does solve the issue), this allows me to do it from the command line.

Edit: I also needed to increase the wait time for vLLM startup, but I didn't add that here. Reasonable to add as a command line arg?

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
