### PR TITLE
Add chunked prefill and limit mm per prompt options

### DIFF
--- a/olmocr/pipeline.py
+++ b/olmocr/pipeline.py
@@ -599,6 +599,8 @@ async def vllm_server_task(model_name_or_path, args, semaphore, unknown_args=Non
         str(args.tensor_parallel_size),
         "--data-parallel-size",
         str(args.data_parallel_size),
+        "--enable-chunked-prefill",
+        "--limit-mm-per-prompt '{\"video\": 0}'"
     ]
 
     if args.gpu_memory_utilization is not None:


### PR DESCRIPTION
The goal of this PR is to supplement the defaults to increase inference speed. I have tested this on a L40S and this has been working fine, with more than 2 weeks of combined uptime running pdf conversion. 

Changes proposed in this pull request:
* `--limit-mm-per-prompt`  allows VLLM to not allocate space on the GPU for the video encoder, thus increasing space for KV cache
* `--enable-chunked-prefill` basically streams the input tokens allowing for more efficient memory use.  

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
