### PR TITLE
[feat] Add ngram speculative decoding to vllm options

### DIFF
--- a/olmocr/pipeline.py
+++ b/olmocr/pipeline.py
@@ -638,6 +638,8 @@ async def vllm_server_task(model_name_or_path, args, semaphore, unknown_args=Non
         str(args.data_parallel_size),
         "--limit-mm-per-prompt",
         '{"video": 0}',  # Disabling video encoder saves RAM that you can put towards the KV cache, thanks @charitarthchugh
+        "--speculative-config",
+        '{"method": "ngram","num_speculative_tokens": 8,"prompt_lookup_max": 64}'
     ]
 
     if args.gpu_memory_utilization is not None:


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

This pull request adds speculative decoding support to the VLLM server task by introducing a new configuration option. This change aims to improve generation efficiency and performance.

Enhancement to VLLM server task:

* Added the `--speculative-config` argument to the VLLM server launch command in `vllm_server_task`, enabling n-gram speculative decoding with specific parameters for the number of speculative tokens and prompt lookup maximum.. 

I have noticed a  ~10-15% speedup with this, depending on the config with L40S.  I think more tuning might be needed to ensure it works well for everyone. 

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.