### PR TITLE
fix: Keep --markdown output inside the workspace (Fixes #391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed markdown export escaping workspace directory when `--pdfs` receives absolute paths. Absolute paths are now safely prefixed with `absolute/` to keep outputs within the workspace. ([#391](https://github.com/allenai/olmocr/issues/391))
+
 ## [v0.4.6](https://github.com/allenai/olmocr/releases/tag/v0.4.6) - 2025-11-17
 
 ## [v0.4.5](https://github.com/allenai/olmocr/releases/tag/v0.4.5) - 2025-11-14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,9 @@ python_classes = [
 ]
 log_format = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
 log_level = "DEBUG"
+
 markers = [
-    "nonci: mark test as not intended for CI runs"
+    "nonci: mark test as not intended for CI runs",
+    "asyncio: mark test as an asyncio coroutine"
 ]
 addopts = "-m 'not nonci'"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,7 +8,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from PIL import Image
 
-from olmocr.pipeline import PageResult, build_page_query, process_page
+from olmocr.pipeline import (
+    PageResult,
+    build_page_query,
+    derive_markdown_relative_path,
+    process_page,
+)
 
 
 def create_test_image(width=100, height=150):
@@ -506,3 +511,37 @@ Document correctly oriented at 90 degrees total rotation."""
         assert build_page_query_calls[0] == 0  # First call with no rotation
         assert build_page_query_calls[1] == 270  # Second call with 270 degree rotation
         assert build_page_query_calls[2] == 90  # Third call with wrapped rotation (270 + 180 = 450 % 360 = 90)
+
+
+class TestMarkdownPathDerivation:
+    def test_relative_path_preserved(self):
+        """Test that relative paths are preserved without modification."""
+        result = derive_markdown_relative_path("tests/gnarly_pdfs/sample.pdf")
+        assert result == os.path.join("tests", "gnarly_pdfs", "sample.pdf")
+
+    def test_absolute_path_prefixed(self, tmp_path):
+        """Test that absolute paths are prefixed with 'absolute/' to keep outputs in workspace."""
+        absolute_pdf = tmp_path / "docs" / "example.pdf"
+        absolute_pdf.parent.mkdir(parents=True, exist_ok=True)
+        absolute_pdf.touch()
+
+        result = derive_markdown_relative_path(str(absolute_pdf))
+        assert result.startswith(os.path.join("absolute", "tmp"))
+        assert result.endswith(os.path.join("docs", "example.pdf"))
+
+    def test_windows_style_path(self):
+        """Test that Windows-style absolute paths (e.g., C:\\path) are handled correctly."""
+        path = r"C:\data\reports\demo.pdf"
+        result = derive_markdown_relative_path(path)
+        assert result.startswith(os.path.join("absolute", "C"))
+        assert result.endswith(os.path.join("data", "reports", "demo.pdf"))
+
+    def test_parent_segments_removed(self):
+        """Test that parent directory traversal attempts (..) are removed from paths."""
+        result = derive_markdown_relative_path("../outside/../doc.pdf")
+        assert result == "doc.pdf"
+
+    def test_s3_path_sanitised(self):
+        """Test that S3 paths are properly sanitised and converted to relative paths."""
+        result = derive_markdown_relative_path("s3://bucket/documents/input.pdf")
+        assert result == os.path.join("documents", "input.pdf")


### PR DESCRIPTION
# Fix: Keep --markdown output inside the workspace

Fixes #391

## Problem

When `--pdfs` receives absolute paths, the markdown export mirrors the full path and escapes the workspace directory. The issue occurs because 
the code previously set `relative_path = source_file` for local files before joining it with `args.workspace`, effectively ignoring the 
workspace prefix.

For example, when processing `/home/user/documents/example.pdf`:
- **Before**: Markdown files were written to `/home/user/documents/example.md` (outside workspace)
- **After**: Markdown files are written to `<workspace>/markdown/absolute/home/user/documents/example.md` (inside workspace)

## Solution

This PR introduces a new function `derive_markdown_relative_path()` that ensures all markdown outputs are safely contained within the 
workspace directory by:

1. **Sanitising path components**: Removing directory traversal attempts (`..`), empty segments, and colons
2. **Handling absolute paths**: Converting absolute paths (both Unix and Windows-style) to relative paths prefixed with `absolute/`
3. **Preserving relative paths**: Keeping relative paths unchanged
4. **Handling S3 paths**: Properly sanitising S3 paths to relative bucket paths

### Key Changes

- **`olmocr/pipeline.py`**:
  - Added `_split_and_sanitize_path()` helper function to break paths into safe components
  - Added `derive_markdown_relative_path()` function to generate workspace-safe relative paths
  - Modified `worker()` function to use `derive_markdown_relative_path()` instead of directly using `source_file`

- **`tests/test_pipeline.py`**:
  - Added `TestMarkdownPathDerivation` test class with 5 comprehensive tests covering:
    - Relative path preservation
    - Absolute path prefixing
    - Windows-style path handling
    - Parent directory traversal removal
    - S3 path sanitisation

- **`pyproject.toml`**:
  - Added `asyncio` marker registration to support async tests (infrastructure improvement)

- **`CHANGELOG.md`**:
  - Added entry documenting this fix in the Unreleased section

## Testing

All new tests pass:
- `test_relative_path_preserved`
- `test_absolute_path_prefixed`
- `test_windows_style_path`
- `test_parent_segments_removed`
- `test_s3_path_sanitised`

## Examples

### Before
```bash
# Input: /home/user/docs/report.pdf
# Output: /home/user/docs/report.md (escapes workspace!)
```

### After
```bash
# Input: /home/user/docs/report.pdf
# Output: <workspace>/markdown/absolute/home/user/docs/report.md (safe!)

# Input: C:\data\reports\demo.pdf
# Output: <workspace>/markdown/absolute/C/data/reports/demo.md (safe!)

# Input: tests/sample.pdf
# Output: <workspace>/markdown/tests/sample.md (preserved relative path)

# Input: s3://bucket/documents/input.pdf
# Output: <workspace>/markdown/documents/input.md (sanitised S3 path)
```

## Security

This fix also prevents directory traversal attacks by removing `..` segments and sanitising all path components before constructing the output 
path.

## Files Changed

- `olmocr/pipeline.py`: Added path sanitisation functions and updated markdown export logic
- `tests/test_pipeline.py`: Added comprehensive test coverage
- `pyproject.toml`: Added asyncio marker registration
- `CHANGELOG.md`: Documented the fix
