### PR TITLE
Fix #433 Prevent per-page hangs & avoid killing job on maxbackoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Pipeline no longer hangs indefinitely when inference server stalls mid-response ([#433](https://github.com/allenai/olmocr/issues/433))
+- Per-page max backoff now falls back gracefully instead of killing the entire job
+
+### Added
+
+- `--request_timeout_s` CLI flag to control per-request timeout (default 120s)
+
 ## [v0.4.25](https://github.com/allenai/olmocr/releases/tag/v0.4.25) - 2026-01-25
 
 ## [v0.4.24](https://github.com/allenai/olmocr/releases/tag/v0.4.24) - 2026-01-23


### PR DESCRIPTION
Closes #433 

Changes proposed in this pull request:
- `apost()` now takes a `timeout_s` param and wraps the entire network path in `asyncio.timeout()`, so a stalled server cant block forever
- When max backoff is exhausted, we return `None` instead of `sys.exit(1)` - the existing fallback path (`make_fallback_result`) handles it from there, so the rest of the PDF still gets processed
- New `--request_timeout_s` CLI flag (default 120s) to control per-request timeout

## Before submitting

- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
