### PR TITLE
fix: parse server endpoint values that include colons

### DIFF
--- a/olmocr/bench/convert.py
+++ b/olmocr/bench/convert.py
@@ -25,7 +25,8 @@ def parse_method_arg(method_arg):
     """
     parts = method_arg.split(":")
     name = parts[0]
-    kwargs = {}
+    raw_kwargs = {}
+    last_key = None
     folder_name = name  # Default folder name is the method name
 
     for extra in parts[1:]:
@@ -33,18 +34,26 @@ def parse_method_arg(method_arg):
             key, value = extra.split("=", 1)
             if key == "name":
                 folder_name = value
+                last_key = None
                 continue
 
-            try:
-                converted = int(value)
-            except ValueError:
-                try:
-                    converted = float(value)
-                except ValueError:
-                    converted = value
-            kwargs[key] = converted
+            raw_kwargs[key] = value
+            last_key = key
         else:
-            raise ValueError(f"Extra argument '{extra}' is not in key=value format")
+            if last_key is None:
+                raise ValueError(f"Extra argument '{extra}' is not in key=value format")
+            raw_kwargs[last_key] = f"{raw_kwargs[last_key]}:{extra}"
+
+    kwargs = {}
+    for key, value in raw_kwargs.items():
+        try:
+            converted = int(value)
+        except ValueError:
+            try:
+                converted = float(value)
+            except ValueError:
+                converted = value
+        kwargs[key] = converted
 
     return name, kwargs, folder_name
 

--- a/tests/test_convert_parse_method_arg.py
+++ b/tests/test_convert_parse_method_arg.py
@@ -1,0 +1,38 @@
+import sys
+import types
+
+pypdf = types.ModuleType("pypdf")
+pypdf.PdfReader = object
+sys.modules.setdefault("pypdf", pypdf)
+
+tqdm_module = types.ModuleType("tqdm")
+tqdm_module.tqdm = lambda iterable, *args, **kwargs: iterable
+sys.modules.setdefault("tqdm", tqdm_module)
+
+renderpdf_module = types.ModuleType("olmocr.data.renderpdf")
+renderpdf_module.render_pdf_to_base64png = lambda *args, **kwargs: None
+sys.modules.setdefault("olmocr.data.renderpdf", renderpdf_module)
+
+image_utils_module = types.ModuleType("olmocr.image_utils")
+image_utils_module.convert_image_to_pdf_bytes = lambda *args, **kwargs: b""
+sys.modules.setdefault("olmocr.image_utils", image_utils_module)
+
+from olmocr.bench.convert import parse_method_arg
+
+
+def test_parse_method_arg_allows_colons_in_value():
+    name, kwargs, folder = parse_method_arg("server:model=gemma-3-27b:endpoint=localhost:8080/v1")
+
+    assert name == "server"
+    assert kwargs["model"] == "gemma-3-27b"
+    assert kwargs["endpoint"] == "localhost:8080/v1"
+    assert folder == "server"
+
+
+def test_parse_method_arg_preserves_numeric_casting():
+    name, kwargs, folder = parse_method_arg("mock:temperature=0.1:max_tokens=128:name=trial")
+
+    assert name == "mock"
+    assert kwargs["temperature"] == 0.1
+    assert kwargs["max_tokens"] == 128
+    assert folder == "trial"


### PR DESCRIPTION
Fixes #445

The parser now treats colon-only segments as a continuation of the previous value, so endpoint strings like `localhost:8080/v1` work correctly instead of failing argument parsing. I also added a focused test for the endpoint case plus a numeric-casting regression check.

Greetings, saschabuehrle
