### PR TITLE
Rework run_server endpoint argument to evade issues with colon

### DIFF
--- a/olmocr/bench/runners/run_server.py
+++ b/olmocr/bench/runners/run_server.py
@@ -24,7 +24,10 @@ from olmocr.prompts.prompts import (
 async def run_server(
     pdf_path: str,
     page_num: int = 1,
-    endpoint: str = "http://localhost:8000/v1",
+    endpoint_scheme: str = "http",
+    endpoint_hostname: str = "localhost",
+    endpoint_port: int = 8000,
+    endpoint_path: str = "/v1",
     model: str = "allenai/olmOCR-7B-0225-preview",
     temperature: float = 0.1,
     target_longest_image_dim: int = 1024,
@@ -62,6 +65,8 @@ async def run_server(
         prompt = build_openai_silver_data_prompt_v3_simple(width, height)
     else:
         raise ValueError("Unknown prompt template")
+
+    endpoint = f"{endpoint_scheme}://{endpoint_hostname}:{str(endpoint_port)}{endpoint_path}",
 
     request = {
         "model": model,

--- a/olmocr/bench/runners/run_server.py
+++ b/olmocr/bench/runners/run_server.py
@@ -27,7 +27,7 @@ async def run_server(
     endpoint_scheme: str = "http",
     endpoint_hostname: str = "localhost",
     endpoint_port: int = 8000,
-    endpoint_path: str = "/v1",
+    endpoint_path: str = "v1",
     model: str = "allenai/olmOCR-7B-0225-preview",
     temperature: float = 0.1,
     target_longest_image_dim: int = 1024,
@@ -66,7 +66,8 @@ async def run_server(
     else:
         raise ValueError("Unknown prompt template")
 
-    endpoint = f"{endpoint_scheme}://{endpoint_hostname}:{str(endpoint_port)}{endpoint_path}",
+    endpoint_path = endpoint_path.lstrip("/")
+    endpoint = f"{endpoint_scheme}://{endpoint_hostname}:{str(endpoint_port)}/{endpoint_path}"
 
     request = {
         "model": model,


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #445

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Split the endpoint argument of run_server into 4 arguments for each part
- Avoids the need of a colon in the arguments
- This evades the issue of the colon being the seperator for the method arguments, which makes it not usable in an argument

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/olmocr/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
