### PR TITLE
fix: escape percent sign in argparse help string

### DIFF
--- a/olmocr/bench/benchmark.py
+++ b/olmocr/bench/benchmark.py
@@ -183,7 +183,7 @@ def main():
         "--confidence_level",
         type=float,
         default=0.95,
-        help="Confidence level for interval calculation (default: 0.95 for 95% CI).",
+        help="Confidence level for interval calculation (default: 0.95 for 95%% CI).",
     )
     # New arguments
     parser.add_argument("--sample", type=int, default=None, help="Randomly sample N tests to run instead of all tests.")


### PR DESCRIPTION
## Problem

Running `python -m olmocr.bench.benchmark --dir ...` crashes with:

```
ValueError: unsupported format character 'C' (0x43) at index 65
```

The argparse help string for `--confidence_level` contains `95% CI`. Python's argparse uses `%`-formatting for help strings, so the literal `%` is interpreted as a format specifier.

## Fix

Escape `95%` to `95%%` in the help string.

Fixes #451