### PR TITLE
fix(bench): guard TextPresenceTest against partial_ratio degenerate case (#461)

### DIFF
--- a/olmocr/bench/tests.py
+++ b/olmocr/bench/tests.py
@@ -164,6 +164,28 @@ class TextPresenceTest(BasePDFTest):
         elif self.last_n:
             md_content = md_content[-self.last_n :]
 
+        # Length guard against rapidfuzz.partial_ratio's symmetric behavior.
+        # partial_ratio scales by min(len(a), len(b)) — when md_content is much
+        # shorter than reference_query the metric inverts: e.g.
+        # partial_ratio("a long phrase", " ") = 1.0, because the single space
+        # in md_content matches the single space inside the query. With
+        # max_diffs=0 the threshold is 1.0 so PRESENT falsely passes and
+        # ABSENT falsely fails for any space-containing query whenever a
+        # downstream pipeline emits effectively empty content (e.g. "\n",
+        # which normalize_text collapses to " "). For PRESENT to be plausibly
+        # satisfiable, md_content needs at least len(reference_query) -
+        # max_diffs characters.
+        min_required = len(reference_query) - self.max_diffs
+        if len(md_content) < min_required:
+            if self.type == TestType.PRESENT.value:
+                msg = (
+                    f"Candidate too short ({len(md_content)} chars) to plausibly contain "
+                    f"'{reference_query[:40]}...' (need >= {min_required} chars)"
+                )
+                return False, msg
+            else:  # ABSENT
+                return True, ""
+
         # Threshold for fuzzy matching derived from max_diffs
         threshold = 1.0 - (self.max_diffs / (len(reference_query) if len(reference_query) > 0 else 1))
         best_ratio = fuzz.partial_ratio(reference_query, md_content) / 100.0

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -185,6 +185,48 @@ class TestTextPresenceTest(unittest.TestCase):
         result, _ = test.run("This document doesn't have the target")
         self.assertTrue(result)
 
+    def test_present_short_candidate_with_space_query_does_not_falsely_pass(self):
+        """Regression: rapidfuzz.partial_ratio scales by min(len(a), len(b)).
+
+        For very short md_content (e.g. "\\n", which normalize_text collapses
+        to " "), partial_ratio(query_with_space, " ") returns 1.0 because a
+        single space character matches a single space inside the query. With
+        max_diffs=0 the threshold is 1.0, so PRESENT tests for any
+        space-containing query falsely passed. A length guard rejects the
+        match before partial_ratio is consulted.
+        """
+        test = TextPresenceTest(
+            pdf="test.pdf", page=1, id="test_id",
+            type=TestType.PRESENT.value,
+            text="an expression of good will from you",
+        )
+        # Empty content
+        result, _ = test.run("")
+        self.assertFalse(result)
+        # Single newline (parserbench's splitter formerly emitted this for
+        # empty parser output; normalize_text collapses to " ")
+        result, _ = test.run("\n")
+        self.assertFalse(result)
+        # Single space directly
+        result, _ = test.run(" ")
+        self.assertFalse(result)
+        # Short content where a coincidental space would otherwise win
+        result, _ = test.run("a b")
+        self.assertFalse(result)
+
+    def test_absent_short_candidate_with_space_query_does_not_falsely_fail(self):
+        """Mirror of the above for ABSENT — must PASS when md_content is too
+        short to plausibly contain the query.
+        """
+        test = TextPresenceTest(
+            pdf="test.pdf", page=1, id="test_id",
+            type=TestType.ABSENT.value,
+            text="TELEPHONE 478",
+        )
+        for short in ("", "\n", " ", "a b"):
+            result, _ = test.run(short)
+            self.assertTrue(result, f"absent should pass for short md={short!r}")
+
     def test_case_insensitive_present(self):
         """Test that case_sensitive=False works for PRESENT test"""
         test = TextPresenceTest(pdf="test.pdf", page=1, id="test_id", type=TestType.PRESENT.value, text="TARGET TEXT", case_sensitive=False)


### PR DESCRIPTION
Closes #461.

## Summary

`TextPresenceTest.run` in `olmocr/bench/tests.py` inverts its decision when the candidate's `md_content` is much shorter than the query. A 1-byte candidate (`"\n"` → `" "` after `normalize_text`) makes most `present` tests falsely pass and most `absent` tests falsely fail, because `rapidfuzz.fuzz.partial_ratio(query, " ")` returns `1.0` for any query containing a space (partial_ratio scales by the shorter string).

Length guard added before `partial_ratio` is consulted:

```python
min_required = len(reference_query) - self.max_diffs
if len(md_content) < min_required:
    if self.type == TestType.PRESENT.value:
        return False, "Candidate too short ..."
    else:  # ABSENT
        return True, ""
```

If the candidate is shorter than the query minus allowed edits, the query cannot be plausibly contained — `present` returns False, `absent` returns True, no `partial_ratio` call needed.

## Real-world signal

Caught running `olmocr.bench.benchmark` against the full `old_scans` slice (98 pages) with `pymupdf4llm` on a Linux container without Tesseract. The parser produced 0-byte output for every page; the splitter wrote `"\n"`. The bench reported aggregate `pass_rate` **0.6183** with **11 pages at perfect 1.0**, while the legitimate empty-output baseline (`absent_count / total_tests` per page) is **~0.13**.

After this patch, same run on same data: aggregate drops to **0.1749**, distribution shifts from "no zeros, 11 perfects" to "45 pages at 0.0, 0 perfects." The residual `0.17 vs 0.13` is real signal from a few PDFs with partial text layers that pymupdf4llm extracts.

## Test plan

- All 148 existing tests in `tests/test_tests.py` continue to pass (`python -m unittest tests.test_tests` returns OK).
- Two new regression tests added in `TestTextPresenceTest`:
  - `test_present_short_candidate_with_space_query_does_not_falsely_pass` — covers empty / `"\n"` / `" "` / `"a b"` candidates against a space-containing query, asserts `present` returns False.
  - `test_absent_short_candidate_with_space_query_does_not_falsely_fail` — same candidates, asserts `absent` returns True.
- Self-contained repro script at the repo root (`repro_partial_ratio_bug.py`): `python repro_partial_ratio_bug.py` returns exit 1 against unpatched code and exit 0 against the patched code.

## Why it matters

The bug isn't specific to "parser produced empty output." Any candidate with a few characters of real content (degraded scans, partial OCR, dropped pages) will inflate against this scoring path. A bench that can't distinguish "no output" from "perfect output" for queries containing a space cannot reliably rank pipelines on degraded inputs — exactly the regime `old_scans` is meant to discriminate.
